### PR TITLE
Added Exponential backoff retry to resourceTopicCreate

### DIFF
--- a/client/topic.go
+++ b/client/topic.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"time"
+	"math"
 )
 
 type Topics struct {
@@ -149,10 +151,23 @@ func createTopic(c Client, t *NewTopic) (*Topic, error) {
 		return nil, err
 	}
 
-	res, err := c.doRequest(req)
-	if err != nil {
-		return nil, err
-	}
+    retryCap := 3
+    res, err := c.doRequest(req)
+    for retry := 1; retry <= retryCap; retry++{
+        if err != nil {
+            fmt.Errorf("%s\n",err)
+            fmt.Println("Waiting to retry...")
+            time.Sleep(time.Duration(math.Pow(float64(retry), 2)) * time.Second)
+            fmt.Printf("Starting retry attempt %d of %d\n", retry, retryCap)
+            res, err := c.doRequest(req)
+            _,_ = res, err
+        } else {
+            break
+        }
+    }
+    if err != nil {
+        return nil, err
+    }
 
 	var topic Topic
 	err = json.Unmarshal(res, &topic)


### PR DESCRIPTION
If the request to create a topic fails, the program will attempt to send the request again up to 3 times. The wait time for each retry will increase exponentially (to the power of 2). So, 1st retry attempt will happen after 1 second, the 2nd after 4 seconds, and the 3rd after 9 seconds.