### PR TITLE
Attempt to fix gpg-agent is already running error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,8 @@ jobs:
         with:
           go-version: 1.15.x
       - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@v5
         id: import_gpg
-        uses: hashicorp/ghaction-import-gpg@v2.1.0
         env:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           PASSPHRASE: ${{ secrets.PASSPHRASE }}


### PR DESCRIPTION
Ran into an error trying to publish provider:
```
gpg-agent[1719]: directory '/home/runner/.gnupg' created
gpg-agent[1719]: directory '/home/runner/.gnupg/private-keys-v1.d' created
gpg-agent: a gpg-agent is already running - not starting a new one
Error: Process completed with exit code 2.
```
Found a potential fix [here](https://github.com/hashicorp/ghaction-import-gpg/issues/11#issuecomment-1185107410)