### PR TITLE
Increased retry wait time from power of 2 to 2.5

### DIFF
--- a/client/topic.go
+++ b/client/topic.go
@@ -157,7 +157,7 @@ func createTopic(c Client, t *NewTopic) (*Topic, error) {
         if err != nil {
             fmt.Printf("%s\n\n",err)
             fmt.Println("Waiting to retry...")
-            time.Sleep(time.Duration(math.Pow(float64(retry), 2)) * time.Second)
+            time.Sleep(time.Duration(math.Pow(float64(retry), 2.5)) * time.Second)
             fmt.Printf("Starting retry attempt %d of %d\n", retry, retryCap)
             res, err := c.doRequest(req)
             _,_ = res, err


### PR DESCRIPTION
For power of 2, wait times for each retry (in seconds) were: 1, 4, 9.
For power of 2.5, wait times are changes to 1, 5.66, 15.58.